### PR TITLE
Build on latest Rust nightly 1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 matrix:
   include:
     - os: linux
-      rust: nightly-2016-10-27
+      rust: nightly-2017-02-13
       env: TARGET=x86_64-unknown-linux-musl
       dist: trusty
       sudo: required

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "ayzim-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "interpolate_idents 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interpolate_idents 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "odds 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -55,7 +55,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "interpolate_idents"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -183,7 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum custom_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1262be99f6e841c8ff80887a156a35fadec70b94011900364eaee73d5f8c26"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
-"checksum interpolate_idents 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "153c5f0218ca99dfe7f5298e9f80527c3676cea7fa46a5bb9b94873379b5694b"
+"checksum interpolate_idents 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f65e540a0a7e7b6afb045604581c92b8757c745202a5e923dda515ee67e6c7ed"
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "ayzim"
 version = "0.1.3-pre"
 dependencies = [
- "ayzim-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ayzim-macros 0.1.1-pre",
  "cfor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "interpolate_idents 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -19,8 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ayzim-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.1-pre"
 
 [[package]]
 name = "cfor"
@@ -177,7 +176,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum ayzim-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1e0a588a08b32ebe91ca3803c2dd83d868a6deb1cf6ff37cad9e2faf7b60c75"
 "checksum cfor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e035019ccf76253261e8ba408182d2d4de6acc4dac78c41b2e5d645df2301205"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1262be99f6e841c8ff80887a156a35fadec70b94011900364eaee73d5f8c26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cfor = "1.1"
 conv = "0.3.2"
 vgrs = { version = "0.1", optional = true }
 
-interpolate_idents = "0.1.1"
+interpolate_idents = "0.1.4"
 #ayzim-macros = { path = "ayzim-macros" }
 ayzim-macros = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ conv = "0.3.2"
 vgrs = { version = "0.1", optional = true }
 
 interpolate_idents = "0.1.4"
-#ayzim-macros = { path = "ayzim-macros" }
-ayzim-macros = "0.1.0"
+ayzim-macros = { path = "ayzim-macros" }
+#ayzim-macros = "0.1.0"
 
 [build-dependencies]
 string_cache_codegen = "0.3.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   # TODO feel free to delete targets/channels you don't need
   matrix:
     - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: nightly-2016-10-27
+      CHANNEL: nightly-2017-02-13
 
 # Install Rust and Cargo
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)

--- a/ayzim-macros/src/lib.rs
+++ b/ayzim-macros/src/lib.rs
@@ -47,7 +47,7 @@ pub fn walk_pat_mut<F>(pat: Pat, it: &mut F) -> Pat where F: FnMut(Pat) -> Pat {
         }
         PatKind::Wild |
         PatKind::Lit(_) |
-        PatKind::Range(_, _) |
+        PatKind::Range(_, _, _) |
         PatKind::Ident(_, _, _) |
         PatKind::Path(..) |
         PatKind::Mac(_) => {


### PR DESCRIPTION
I'd like to try Ayzim but I cannot build it with Rust 1.15.1. So I upgraded Rust into nightly 1.17.0.
Some errors occur when building on the nightly Rust `rustc 1.17.0-nightly (536a900c4 2017-02-17)`.
This pull request fixes the build errors.